### PR TITLE
Fix annotation removal bug

### DIFF
--- a/pkg/quack/quack.go
+++ b/pkg/quack/quack.go
@@ -20,6 +20,7 @@ import (
 
 const (
 	lastAppliedConfigPath = "/metadata/annotations/kubectl.kubernetes.io~1last-applied-configuration"
+	quackAnnotationPrefix = "/metadata/annotations/quack.pusher.com"
 	leftDelimAnnotation   = "quack.pusher.com/left-delim"
 	rightDelimAnnotation  = "quack.pusher.com/right-delim"
 )
@@ -168,7 +169,7 @@ func createPatch(old []byte, new []byte) ([]byte, error) {
 	allowedOps := []jsonpatch.JsonPatchOperation{}
 	for _, op := range patch {
 		// Don't patch the lastAppliedConfig created by kubectl
-		if op.Path == lastAppliedConfigPath {
+		if op.Path == lastAppliedConfigPath || strings.HasPrefix(op.Path, quackAnnotationPrefix) {
 			continue
 		}
 		allowedOps = append(allowedOps, op)

--- a/pkg/quack/quack_test.go
+++ b/pkg/quack/quack_test.go
@@ -152,13 +152,19 @@ func TestGetTemplateInput(t *testing.T) {
 	object := testObject{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
-				"annotation": "value",
+				"annotation":           "value",
+				"quack.pusher.com/foo": "bar",
 			},
 		},
 		Foo: "bar",
 	}
-	objectNoAnnotations := testObject{
+	objectNoQuackAnnotations := testObject{
 		Foo: "bar",
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"annotation": "value",
+			},
+		},
 	}
 
 	objectRaw, err := json.Marshal(object)
@@ -176,7 +182,7 @@ func TestGetTemplateInput(t *testing.T) {
 	if err != nil {
 		assert.FailNowf(t, "jsonError", "Error in unmarshall: %v", err)
 	}
-	assert.Equal(t, objectNoAnnotations, templateObject, "Object should have no annotations")
+	assert.Equal(t, objectNoQuackAnnotations, templateObject, "Object should have no quack annotations")
 }
 
 func TestGetDelims(t *testing.T) {


### PR DESCRIPTION
This fixes a bug in v0.2.0 where annotations are removed from templated objects.

Now it removes the quack specific annotations before sending through the templater and then ignores any operation to remove or change a quack specific annotation before sending the response