### PR TITLE
Add Ignored Paths flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <img src="./logo.svg" width=150 height=150 alt="Quack Logo"/>
 
 # Quack
+
 In-Cluster templating using the Go Template syntax.
 
 **Note:** This is a proof of concept in the early alpha stage.
@@ -11,18 +12,20 @@ complex.
 Please see the [Installation](#installation) section for further detail.
 
 ## Table of contents
-* [Introduction](#introduction)
-* [Installation](#installation)
-  * [Deploying to Kubernetes](#deploying-to-kubernetes)
-  * [Configuration](#configuration)
-* [Example Quack Template](#example-quack-template)
-  * [Custom Delimiters](#custom-delimiters)
-* [Quack vs Other Systems](#quack-vs-other-systems)
-* [Communication](#communication)
-* [Contributing](#contributing)
-* [License](#license)
+
+- [Introduction](#introduction)
+- [Installation](#installation)
+  - [Deploying to Kubernetes](#deploying-to-kubernetes)
+  - [Configuration](#configuration)
+- [Example Quack Template](#example-quack-template)
+  - [Custom Delimiters](#custom-delimiters)
+- [Quack vs Other Systems](#quack-vs-other-systems)
+- [Communication](#communication)
+- [Contributing](#contributing)
+- [License](#license)
 
 ## Introduction
+
 Client Side templating can be error prone. When running multiple Kubernetes
 clusters it can be very easy to apply rendered templates to the wrong
 cluster.
@@ -35,7 +38,7 @@ create and update Kubernetes resources such as Deployments, Ingresses and
 ConfigMaps.
 
 Any resource that contains Go Template syntax will be templated (using values
-  from Quack's ConfigMap) before it passes through API validation.
+from Quack's ConfigMap) before it passes through API validation.
 
 Quack is ideal for templating Cluster-wide environment such as the Cluster Name,
 Region and Environment (Staging/Production).
@@ -43,9 +46,11 @@ Region and Environment (Staging/Production).
 ## Installation
 
 ### Deploying to Kubernetes
+
 Example Kubernetes manifests are in the [deploy](/deploy) folder.
 
 #### Quack RBAC
+
 Quack uses RBAC to ensure that requests for templating are authorized.
 If you are running RBAC within your Kubernetes cluster you must ensure that
 you configure Webhook Authentication in your Kubernetes API server.
@@ -56,6 +61,7 @@ Once you have configured the API server authentication, ensure you update the
 appropriate subject.
 
 #### Certificates
+
 Quack requires a TLS certificate for serving the webhook securely.
 This certificate **must** be signed by a CA certificate.
 
@@ -84,25 +90,33 @@ type: Opaque
 ```
 
 ### Configuration
+
 Quack adopts the standard Kubernetes Generic API server flags (including
 Authentication and Authorization flags).
 It loads the In Cluster configuration by default but this can be overridden
 by the `--kubeconfig` flag.
 
 Quack takes the following additional flags:
+
 - `--values-configmap` (Default: `quack-values`): Defines the name of the
-ConfigMap to load cluster level template values from.
+  ConfigMap to load cluster level template values from.
 - `--values-configmap-namespace` (Default: `quack`): Defines the namespace in
-which the Values ConfigMap exists.
+  which the Values ConfigMap exists.
 - `--required-annotation`: Filter objects based on the existence of a named
-annotation before templating them.
+  annotation before templating them.
+- `--ignore-path`: Ignore patches for certain paths in when templating files.
+  May be called multiple times. Paths should be specified as
+  [RFC6901 JSON Pointers](https://tools.ietf.org/html/rfc6901).
 
 #### Restricting Quack
+
 You should configure Quack to only template the resources you need it to
 template.
 
 There are three parts to restricting Quack:
+
 ##### Namespace
+
 A Namespace selector in the
 [MutatingWebhookConfiguration](deploy/mutatingwebhookconfiguration.yaml)
 must be matched for resources within the Namespace to be templated by Quack.
@@ -117,6 +131,7 @@ metadata:
 ```
 
 ##### Resource rules
+
 A list of resoucre rules in the
 [MutatingWebhookConfiguration](deploy/mutatingwebhookconfiguration.yaml)
 must be matched for resources to be templated by Quack.
@@ -138,6 +153,7 @@ rules:
 ```
 
 ##### Required annotation
+
 Using the flag `--required-annotation`, you can tell Quack to skip templating
 for any resource not annotated appropriately.
 
@@ -155,6 +171,7 @@ metadata:
 ```
 
 ## Example Quack Template
+
 In this example, we are defining an Ingress object for the Kubernetes Dashboard.
 
 We suppose that there is an existing Kubernetes cluster known as `alpha`.
@@ -175,10 +192,13 @@ data:
 ```
 
 Create the Ingress object as below and apply it to the cluster:
+
 ```sh
 kubectl apply -f ingress.yaml
 ```
+
 ingress.yaml:
+
 ```yaml
 apiVersion: extensions/v1beta1
 kind: Ingress
@@ -228,6 +248,7 @@ directly to each cluster and the resulting Kubernetes resources will be correct
 for their cluster's particular environment.
 
 ### Custom Delimiters
+
 Each individual Quack template can specify their own delimiters for use against
 the template.
 
@@ -248,25 +269,28 @@ spec:
 ```
 
 ## Quack vs Other Systems
+
 - Quack intercepts the standard flow of `kubectl apply`. This means there are no
-extra tools and no additional syntax to learn, bar the Go Templating Syntax.
+  extra tools and no additional syntax to learn, bar the Go Templating Syntax.
 - Resources are still created using the main Kubernetes API server. This means
-that regular syntax validation and Authorization still happen as the object is
-being created or updated.
+  that regular syntax validation and Authorization still happen as the object is
+  being created or updated.
 - Cluster specific values are stored in cluster and separate from your templates.
-Allows you to keep one copy of Kubernetes manifests and reuse them across all
-clusters without any client side changes.
+  Allows you to keep one copy of Kubernetes manifests and reuse them across all
+  clusters without any client side changes.
 - Protects against mistakenly applying manifests cross clusters. (Templates have
   no specific configuration for each cluster, Quack abstracts this.)
 
 ## Communication
 
-* Found a bug? Please open an issue.
-* Have a feature request. Please open an issue.
-* If you want to contribute, please submit a pull request
+- Found a bug? Please open an issue.
+- Have a feature request. Please open an issue.
+- If you want to contribute, please submit a pull request
 
 ## Contributing
+
 Please see our [Contributing](CONTRIBUTING.md) guidelines.
 
 ## License
+
 This project is licensed under Apache 2.0 and a copy of the license is available [here](LICENSE).

--- a/cmd/quack/main.go
+++ b/cmd/quack/main.go
@@ -24,6 +24,7 @@ func main() {
 	flagset.StringVarP(&ah.ValuesMapName, "values-configmap", "c", "quack-values", "Defines the name of the ConfigMap to load templating values from")
 	flagset.StringVarP(&ah.ValuesMapNamespace, "values-configmap-namespace", "n", "quack", "Defines the namespace to load the Values ConfigMap from")
 	flagset.StringVarP(&ah.RequiredAnnotation, "required-annotation", "a", "", "Require annotation on objects before templating them")
+	flagset.StringSliceVar(&ah.IgnoredPaths, "ignore-path", []string{}, "Ignore patches that are applied to this path")
 
 	// Run server
 	runAdmissionServer(flagset, ah)


### PR DESCRIPTION
Allows users to ignore paths when patching documents, this will be useful for projects that encode JSON data in annotations like kubectl (Which is already ignored)