### PR TITLE
Don't template status fields

### DIFF
--- a/pkg/quack/quack.go
+++ b/pkg/quack/quack.go
@@ -189,7 +189,15 @@ func getTemplateInput(data []byte) ([]byte, error) {
 		return nil, fmt.Errorf("error reading object metadata: %v", err)
 	}
 
-	var patchedData []byte
+	// We should not modify the status of objects
+	patch := []byte(fmt.Sprintf(`[
+		{"op": "remove", "path": "/status"}
+	]`))
+	data, err = applyPatch(data, patch)
+	if err != nil {
+		return nil, fmt.Errorf("error removing status: %v", err)
+	}
+
 	for annotation := range objectMeta.Annotations {
 		if strings.HasPrefix(annotation, "quack.pusher.com") {
 			// Remove annotations from input template
@@ -197,14 +205,14 @@ func getTemplateInput(data []byte) ([]byte, error) {
 			patch := []byte(fmt.Sprintf(`[
 				{"op": "remove", "path": "/metadata/annotations/%s"}
 			]`, escapedAnnotation))
-			patchedData, err = applyPatch(data, patch)
+			data, err = applyPatch(data, patch)
 			if err != nil {
 				return nil, fmt.Errorf("error removing annotation %s: %v", annotation, err)
 			}
 		}
 	}
 
-	return patchedData, nil
+	return data, nil
 }
 
 func requestHasAnnotation(requiredAnnotation string, raw []byte) (bool, error) {


### PR DESCRIPTION
Status fields are not for Quack to be concerned with.

This is a breaking change but I think it's the right direction to go.

This should fix the issue @samuelyallop-pusher has been having syncing dashboard CRDs with Faros