### PR TITLE
Check status exists before trying to remove it

### DIFF
--- a/pkg/quack/quack.go
+++ b/pkg/quack/quack.go
@@ -194,12 +194,18 @@ func getTemplateInput(data []byte) ([]byte, error) {
 	}
 
 	// We should not modify the status of objects
-	patch := []byte(fmt.Sprintf(`[
-		{"op": "remove", "path": "/status"}
-	]`))
-	data, err = applyPatch(data, patch)
+	hasStatus, err := requestHasStatus(data)
 	if err != nil {
-		return nil, fmt.Errorf("error removing status: %v", err)
+		return nil, fmt.Errorf("error reading object status: %v", err)
+	}
+	if hasStatus {
+		patch := []byte(fmt.Sprintf(`[
+			{"op": "remove", "path": "/status"}
+		]`))
+		data, err = applyPatch(data, patch)
+		if err != nil {
+			return nil, fmt.Errorf("error removing status: %v", err)
+		}
 	}
 
 	for annotation := range objectMeta.Annotations {
@@ -250,6 +256,17 @@ func getObjectMeta(raw []byte) (metav1.ObjectMeta, error) {
 		return metav1.ObjectMeta{}, fmt.Errorf("failed to unmarshal input: %v", err)
 	}
 	return requestMeta.ObjectMeta, nil
+}
+
+func requestHasStatus(raw []byte) (bool, error) {
+	requestStatus := struct {
+		Status map[string]string `json:"status"`
+	}{}
+	err := json.Unmarshal(raw, &requestStatus)
+	if err != nil {
+		return false, fmt.Errorf("failed to unmarshal input: %v", err)
+	}
+	return requestStatus.Status != nil, nil
 }
 
 func applyPatch(data, patchBytes []byte) ([]byte, error) {

--- a/pkg/quack/quack.go
+++ b/pkg/quack/quack.go
@@ -106,7 +106,7 @@ func (ah *AdmissionHook) Admit(req *admissionv1beta1.AdmissionRequest) *admissio
 
 	templateInput, err := getTemplateInput(req.Object.Raw)
 	if err != nil {
-		return errorResponse(resp, "")
+		return errorResponse(resp, "Error creating template input: %v", err)
 	}
 	// Run Templating
 	glog.V(6).Infof("Input for %s: %s", requestName, templateInput)

--- a/pkg/quack/quack.go
+++ b/pkg/quack/quack.go
@@ -260,7 +260,7 @@ func getObjectMeta(raw []byte) (metav1.ObjectMeta, error) {
 
 func requestHasStatus(raw []byte) (bool, error) {
 	requestStatus := struct {
-		Status map[string]string `json:"status"`
+		Status map[string]interface{} `json:"status"`
 	}{}
 	err := json.Unmarshal(raw, &requestStatus)
 	if err != nil {

--- a/pkg/quack/quack_test.go
+++ b/pkg/quack/quack_test.go
@@ -342,3 +342,21 @@ func TestGetDelims(t *testing.T) {
 	assert.Equal(t, delimiters{}, withEmptyDelimeters, "Object with empty delimiter should return empty delimiters")
 	assert.NotNil(t, emptyErr, "Object with empty left delimiter should return error")
 }
+
+func TestRequestHasStatus(t *testing.T) {
+	withStatus := `{
+			"status": {
+				"foo": "bar"
+			}
+		}`
+	hasStatus, err := requestHasStatus([]byte(withStatus))
+	assert.Equal(t, nil, err, "Error should not have occurred")
+	assert.Equal(t, true, hasStatus, "Expected object with status to return true")
+
+	withoutStatus := `{
+				"foo": "bar"
+			}`
+	hasStatus, err = requestHasStatus([]byte(withoutStatus))
+	assert.Equal(t, nil, err, "Error should not have occurred")
+	assert.Equal(t, false, hasStatus, "Expected object without status to return false")
+}

--- a/pkg/quack/quack_test.go
+++ b/pkg/quack/quack_test.go
@@ -346,7 +346,8 @@ func TestGetDelims(t *testing.T) {
 func TestRequestHasStatus(t *testing.T) {
 	withStatus := `{
 			"status": {
-				"foo": "bar"
+				"foo": "bar",
+				"baz": 3
 			}
 		}`
 	hasStatus, err := requestHasStatus([]byte(withStatus))


### PR DESCRIPTION
In v0.3.0 if the object being Quack'ed has no status field, there will be an `Internal Server Error` produced.

This is because we are returning an empty error string but the error that should have been produced is: 
```
Error creating template input: error removing status: unable to apply patch: Unable to remove nonexistent key: status
```

This fix checks for the existence of the status field within the JSON before attempting to remove it