### PR TITLE
Properly deal with ignored paths in #getTemplateInput

### DIFF
--- a/pkg/quack/quack.go
+++ b/pkg/quack/quack.go
@@ -212,9 +212,11 @@ func getTemplateInput(data []byte, ignoredPaths []string) ([]byte, error) {
 		patch := []byte(fmt.Sprintf(`[
 			{"op": "remove", "path": "%s"}
 		]`, path))
-		data, err = applyPatch(data, patch)
+		newData, err := applyPatch(data, patch)
 		if err != nil && !nonExistentPath(err) {
 			return nil, fmt.Errorf("error removing %s: %v", path, err)
+		} else if newData != nil {
+			data = newData
 		}
 	}
 

--- a/pkg/quack/quack_test.go
+++ b/pkg/quack/quack_test.go
@@ -233,8 +233,9 @@ func TestGetTemplateInputRemovesIgnoredPaths(t *testing.T) {
 	object := testObject{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
-				"annotation":       "value",
-				"other/annotation": "bar",
+				"annotation":                "value",
+				"quack.pusher.com/template": "true",
+				"other/annotation":          "bar",
 			},
 		},
 		Foo: "bar",
@@ -253,17 +254,37 @@ func TestGetTemplateInputRemovesIgnoredPaths(t *testing.T) {
 	if err != nil {
 		assert.FailNowf(t, "jsonError", "Failed to marshal input: %v", err)
 	}
+	objectNoOtherRaw, err := json.Marshal(objectNoOtherAnnotation)
+	if err != nil {
+		assert.FailNowf(t, "jsonError", "Failed to marshal input: %v", err)
+	}
 
 	template, err := getTemplateInput(objectRaw, ignoredPaths)
 	if err != nil {
 		assert.FailNowf(t, "methodError", "Error in getTemplateInput: %v", err)
 	}
 
+	assert.NotNil(t, template, "template should not be nil")
+
 	templateObject := testObject{}
 	err = json.Unmarshal(template, &templateObject)
 	if err != nil {
 		assert.FailNowf(t, "jsonError", "Error in unmarshall: %v", err)
 	}
+	assert.Equal(t, objectNoOtherAnnotation, templateObject, "Object should have no ignored paths")
+
+	template, err = getTemplateInput(objectNoOtherRaw, ignoredPaths)
+	if err != nil {
+		assert.FailNowf(t, "methodError", "Error in getTemplateInput: %v", err)
+	}
+
+	assert.NotNil(t, template, "template should not be nil")
+
+	err = json.Unmarshal(template, &templateObject)
+	if err != nil {
+		assert.FailNowf(t, "jsonError", "Error in unmarshall: %v", err)
+	}
+
 	assert.Equal(t, objectNoOtherAnnotation, templateObject, "Object should have no ignored paths")
 }
 


### PR DESCRIPTION
The previous "solution" didn't deal with the fact that _when_ an ignore path is not present in the input data, `applyPatch` will actually return `nil` and not the new state (as it would if the patch was successful).

Now we instead assign the output data to a new variable, and only if it's actually something useful (i.e. not nil) we'll eventually return it.