### PR TITLE
Ignore kubectl last applied annotation by default

### DIFF
--- a/pkg/quack/quack.go
+++ b/pkg/quack/quack.go
@@ -46,6 +46,11 @@ func (ah *AdmissionHook) Initialize(kubeClientConfig *restclient.Config, stopCh 
 	}
 	ah.client = client
 
+	// Add lastAppliedConfigPath to ignored paths, unless it's already present
+	if !contains(ah.IgnoredPaths, lastAppliedConfigPath) {
+		ah.IgnoredPaths = append(ah.IgnoredPaths, lastAppliedConfigPath)
+	}
+
 	glog.Info("Webhook Initialization Complete.")
 	return nil
 }


### PR DESCRIPTION
Quack currently doesn't work properly with custom delimiters, at least not if one is trying to use `kubectl apply` as the input template contains itself (I *think* the main issue is that things get escaped too
many times and the `template` package errors out).

This PR makes sure that the path for kubectl's last applied configuration annotation is added to the list of ignored paths (unless it's already present in the list).